### PR TITLE
Feature/render projects

### DIFF
--- a/src/components/experienceCard.tsx
+++ b/src/components/experienceCard.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from "react"
+import { FC } from "react"
 
 type Props = {
   id: number
@@ -8,7 +8,7 @@ type Props = {
   overview: Array<string>
 }
 
-const ExperienceCard: FunctionComponent<Props> = ({name, location, duration, overview}) => {
+const ExperienceCard: FC<Props> = ({name, location, duration, overview}) => {
   const overViewList = overview.map((item, index) => {
 
     return (

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -1,37 +1,40 @@
+import useSWR from 'swr'
+import fetcher from '@utilities/apiCalls'
+import ProjectsCard from './projectsCard'
+
+type ProjectData = {
+  id: number
+  name: string
+  description: string
+  image: string
+  deployLink: string
+  githubRepo: string
+}[]
 
 const Projects = () => {
+  const { data, error, isLoading } = useSWR<ProjectData>('/api/projectInfo', fetcher)
+
+  const projectList = data?.map(project => {
+    const {id, name, description, image, deployLink, githubRepo} = project
+
+    return (
+      <ProjectsCard
+      id={id}
+      name={name}
+      description={description}
+      image={image}
+      deployLink={deployLink}
+      githubRepo={githubRepo}
+      key={id}
+      />
+    )
+  })
+
   return (
     <section id="projects" className="h-[55rem] w-screen bg-[#293744] text-[#a89fa3] text-center snap-center">
       <h2 className='text-4xl py-8'>Projects</h2> {/* Array of mapped objects, swipeable */}
       <div className="flex justify-evenly">
-        <div>
-          <h4>Project 1 Title</h4>
-          <p>Description</p>
-          <p>Image</p>
-          <p>Deploy Link</p>
-          <p>GitHub Repo</p>
-        </div>
-        <div>
-          <h4>Project 2 Title</h4>
-          <p>Description</p>
-          <p>Image</p>
-          <p>Deploy Link</p>
-          <p>GitHub Repo</p>
-        </div>
-        <div>
-          <h4>Project 3 Title</h4>
-          <p>Description</p>
-          <p>Image</p>
-          <p>Deploy Link</p>
-          <p>GitHub Repo</p>
-        </div>
-        <div>
-          <h4>Project 4 Title</h4>
-          <p>Description</p>
-          <p>Image</p>
-          <p>Deploy Link</p>
-          <p>GitHub Repo</p>
-        </div>
+        {projectList}
       </div>
     </section>
   )

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -7,7 +7,6 @@ const Projects = () => {
         <div>
           <h4>Project 1 Title</h4>
           <p>Description</p>
-          <p>Tech Stack</p>
           <p>Image</p>
           <p>Deploy Link</p>
           <p>GitHub Repo</p>
@@ -15,7 +14,6 @@ const Projects = () => {
         <div>
           <h4>Project 2 Title</h4>
           <p>Description</p>
-          <p>Tech Stack</p>
           <p>Image</p>
           <p>Deploy Link</p>
           <p>GitHub Repo</p>
@@ -23,7 +21,6 @@ const Projects = () => {
         <div>
           <h4>Project 3 Title</h4>
           <p>Description</p>
-          <p>Tech Stack</p>
           <p>Image</p>
           <p>Deploy Link</p>
           <p>GitHub Repo</p>
@@ -31,7 +28,6 @@ const Projects = () => {
         <div>
           <h4>Project 4 Title</h4>
           <p>Description</p>
-          <p>Tech Stack</p>
           <p>Image</p>
           <p>Deploy Link</p>
           <p>GitHub Repo</p>

--- a/src/components/projectsCard.tsx
+++ b/src/components/projectsCard.tsx
@@ -1,0 +1,8 @@
+
+const ProjectsCard = () => {
+  return (
+    <div>
+      Placeholder!
+    </div>
+  )
+}

--- a/src/components/projectsCard.tsx
+++ b/src/components/projectsCard.tsx
@@ -1,8 +1,25 @@
+import { FC } from "react"
 
-const ProjectsCard = () => {
+type Props = {
+  id: number
+  name: string
+  description: string
+  image: string
+  deployLink: string
+  githubRepo: string
+}
+
+const ProjectsCard:FC<Props> = ({name, description, image, deployLink, githubRepo}) => {
+
   return (
-    <div>
-      Placeholder!
-    </div>
+    <section>
+      <h3>{name}</h3>
+      <p>{description}</p>
+      <p>{image}</p>
+      <p>{deployLink}</p>
+      <p>{githubRepo}</p>
+    </section>
   )
 }
+
+export default ProjectsCard

--- a/src/pages/api/projectInfo.tsx
+++ b/src/pages/api/projectInfo.tsx
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+type Data = {
+  id: number
+  name: string
+  description: string
+  image: string
+  deployLink: string
+  githubRepo: string
+}[]
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  res.status(200).json([
+    {
+      id: 1,
+      name: "Project 1 Title",
+      description: "A cool project 1",
+      image: "https://picsum.photos/200/300",
+      deployLink: "https://example.com/",
+      githubRepo: "https://github.com/Ant-Shell/"
+
+    },
+    {
+      id: 2,
+      name: "Project 2 Title",
+      description: "A cool project 2",
+      image: "https://picsum.photos/200/300",
+      deployLink: "https://example.com/",
+      githubRepo: "https://github.com/Ant-Shell/"
+    },
+    {
+      id: 3,
+      name: "Project 3 Title",
+      description: "A cool project 3",
+      image: "https://picsum.photos/200/300",
+      deployLink: "https://example.com/",
+      githubRepo: "https://github.com/Ant-Shell/"
+    },
+    {
+      id: 4,
+      name: "Project 4 Title",
+      description: "A cool project 4",
+      image: "https://picsum.photos/200/300",
+      deployLink: "https://example.com/",
+      githubRepo: "https://github.com/Ant-Shell/"
+    },
+  ]
+  )
+}


### PR DESCRIPTION
- Add placeholder information in src/pages/api/projectInfo.tsx
- Fetch, map and render placeholder info in src/components/projects.tsx 
- Pass props for rendering in src/components/projectsCard.tsx
- Use shorthand `FC` in src/components/experienceCard.tsx
- Note: Can refactor functional components at a later time per:
- https://medium.com/raccoons-group/why-you-probably-shouldnt-use-react-fc-to-type-your-react-components-37ca1243dd13
- https://juhanajauhiainen.com/posts/should-you-use-reactfc-to-type-your-components